### PR TITLE
Feat: Vuex-Persist Plugin

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -15,7 +15,9 @@ const defaults = {
   }
 }
 
-module.exports = async function module (moduleOptions) {
+export { default as VuexPersist } from './vuex-persist'
+
+export default async function module (moduleOptions) {
   const options = Object.assign(defaults, this.options.storage, moduleOptions)
 
   this.addPlugin({
@@ -27,6 +29,12 @@ module.exports = async function module (moduleOptions) {
   this.addTemplate({
     src: resolve(__dirname, 'storage.js'),
     fileName: 'storage/storage.js',
+    options
+  })
+
+  this.addTemplate({
+    src: resolve(__dirname, 'vuex-persist.js'),
+    fileName: 'storage/vuex-persist.js',
     options
   })
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -216,7 +216,7 @@ export default class Storage {
 
     const cookies = this.getCookies()
 
-    const value = cookies[_key] ? decodeURIComponent(cookies[_key]): undefined;
+    const value = cookies[_key] ? decodeURIComponent(cookies[_key]) : undefined
 
     return decodeValue(value)
   }
@@ -238,7 +238,7 @@ function isSet (o) {
   return !isUnset(o)
 }
 
-function isObjectOrArray(obj) {
+function isObjectOrArray (obj) {
   const type = Object.prototype.toString.call(obj)
   return type === '[object Object]' || type === '[object Array]'
 }

--- a/lib/vuex-persist.js
+++ b/lib/vuex-persist.js
@@ -1,16 +1,35 @@
 import pickBy from 'lodash/pickBy'
 import merge from 'lodash/merge'
 
+let noop = () => {}
+
+/**
+ * Creator of vuex plugin
+ *
+ * @param {Object} options
+ * @param {String} options.key
+ * @param {Storage} options.storage
+ * @param {function(boolean)} options.expired - Returns true if savedState is not valid and should be cleared
+ * @param {Number} options.expireAfter - Sets expiration time limit. (shouldn't appear with expired)
+ * @param {function(boolean)} options.filter - Ignores some mutations
+ * @param {function(Object)} options.reducer - Reduce state for persistence
+ * @param {Array} options.only - Defines only keys in state to be persist (shouldn't appear with `ignore` or `reducer`)
+ * @param {Array} options.ignore - Defines keys to ignore in state to be persist (shouldn't appear with `only` or `reducer`)
+ * @returns {function(*)}
+ */
 export default function (options) {
   let key = options.key || 'store'
   let storage = options.storage || (typeof window !== 'undefined' ? window.localStorage : {})
+  if (!storage) {
+    throw new function () { this.msg = 'Storage is not valid.' }()
+  }
 
   // Set expiration strategy
   let expired = (state) => false
   if (options.expired && typeof expired === 'function') {
     expired = options.expired
   } else if (options.expireAfter && typeof options.expireAfter === 'number') {
-    expired = (state) => state.timestamp < options.expireAfter
+    expired = (state) => Date.now() > state.timestamp + options.expireAfter * 1000
   }
 
   // Set filters for mutations (ignores some mutations to sync with storage)
@@ -30,9 +49,14 @@ export default function (options) {
   }
 
   // Initial Getter, Setter, Clear for defined storage
-  let setState = (state) => storage.setItem(key, JSON.stringify({ data: state, timestamp: Date.now() }))
-  let getState = () => JSON.parse(storage.getItem(key))
-  let clearState = () => storage.removeItem(key)
+  let setState = noop
+  let getState = noop
+  let clearState = noop
+  if (storage.setItem && storage.getItem && storage.removeItem) {
+    setState = (state) => storage.setItem(key, JSON.stringify({ data: state, timestamp: Date.now() }))
+    getState = () => JSON.parse(storage.getItem(key))
+    clearState = () => storage.removeItem(key)
+  }
 
   return store => {
     const savedState = getState()
@@ -40,7 +64,10 @@ export default function (options) {
     if (typeof savedState === 'object' && savedState !== null) {
       if (savedState.data && !expired(savedState)) {
         // Replace store state with persisted one, if it's not expired (Merges recursively)
-        store.replaceState(merge(store.state, savedState.data))
+        // SetTimeout is used to prevent SSR to unexpectedly change state
+        setTimeout(() => {
+          store.replaceState(merge({}, store.state, savedState.data))
+        }, 1);
       } else {
         // Clear state if expired
         clearState()

--- a/lib/vuex-persist.js
+++ b/lib/vuex-persist.js
@@ -1,0 +1,57 @@
+import pickBy from 'lodash/pickBy'
+import merge from 'lodash/merge'
+
+export default function (options) {
+  let key = options.key || 'store'
+  let storage = options.storage || (typeof window !== 'undefined' ? window.localStorage : {})
+
+  // Set expiration strategy
+  let expired = (state) => false
+  if (options.expired && typeof expired === 'function') {
+    expired = options.expired
+  } else if (options.expireAfter && typeof options.expireAfter === 'number') {
+    expired = (state) => state.timestamp < options.expireAfter
+  }
+
+  // Set filters for mutations (ignores some mutations to sync with storage)
+  let filter = (mutation) => true
+  if (options.filter && typeof options.filter === 'function') {
+    filter = options.filter
+  }
+
+  // Sets a reducer to define which keys of state needed to be persisted
+  let reducer = (state) => state
+  if (options.reducer && typeof options.reducer === 'function') {
+    reducer = options.reducer
+  } else if (options.only) {
+    reducer = (state) => pickBy(state, (value, key) => options.only.indexOf(key) >= 0)
+  } else if (options.ignore) {
+    reducer = (state) => pickBy(state, (value, key) => options.ignore.indexOf(key) === -1)
+  }
+
+  // Initial Getter, Setter, Clear for defined storage
+  let setState = (state) => storage.setItem(key, JSON.stringify({ data: state, timestamp: Date.now() }))
+  let getState = () => JSON.parse(storage.getItem(key))
+  let clearState = () => storage.removeItem(key)
+
+  return store => {
+    const savedState = getState()
+
+    if (typeof savedState === 'object' && savedState !== null) {
+      if (savedState.data && !expired(savedState)) {
+        // Replace store state with persisted one, if it's not expired (Merges recursively)
+        store.replaceState(merge(store.state, savedState.data))
+      } else {
+        // Clear state if expired
+        clearState()
+      }
+    }
+
+    // Listen to all mutations that passes the filter to persist the state
+    store.subscribe((mutation, state) => {
+      if (filter(mutation)) {
+        setState(reducer(state))
+      }
+    })
+  }
+}

--- a/lib/vuex-persist.js
+++ b/lib/vuex-persist.js
@@ -67,7 +67,7 @@ export default function (options) {
         // SetTimeout is used to prevent SSR to unexpectedly change state
         setTimeout(() => {
           store.replaceState(merge({}, store.state, savedState.data))
-        }, 1);
+        }, 1)
       } else {
         // Clear state if expired
         clearState()

--- a/lib/vuex-persist.js
+++ b/lib/vuex-persist.js
@@ -21,12 +21,12 @@ export default function (options) {
   let key = options.key || 'store'
   let storage = options.storage || (typeof window !== 'undefined' ? window.localStorage : {})
   if (!storage) {
-    throw new function () { this.msg = 'Storage is not valid.' }()
+    throw Error('Storage is not valid.')
   }
 
   // Set expiration strategy
   let expired = (state) => false
-  if (options.expired && typeof expired === 'function') {
+  if (options.expired && typeof options.expired === 'function') {
     expired = options.expired
   } else if (options.expireAfter && typeof options.expireAfter === 'number') {
     expired = (state) => Date.now() > state.timestamp + options.expireAfter * 1000

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
-<div>
+<div align="center">
+  <h5>Works!</h5>
   {{ $storage.state }}
 </div>
 </template>

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-  {{ $storage.state }}
+  {{ $store.state }}
 </div>
 </template>
 

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-  {{ $store.state }}
+  {{ $storage.state }}
 </div>
 </template>
 

--- a/test/fixture/store/index.js
+++ b/test/fixture/store/index.js
@@ -1,4 +1,4 @@
-import VuexPersist from '@@/lib/vuex-persist'
+import { VuexPersist } from '@@'
 
 export const state = () => ({
 

--- a/test/fixture/store/index.js
+++ b/test/fixture/store/index.js
@@ -1,0 +1,18 @@
+import VuexPersist from '@@/lib/vuex-persist'
+
+export const state = () => ({
+
+  myState: 'Welcome!'
+
+})
+
+export const mutations = {
+  changeState (state, value) {
+    state.myState = value
+  }
+}
+
+export const plugins = [VuexPersist({
+  storage: (typeof window !== 'undefined' ? window.localStorage : {}),
+  expireAfter: 10
+})]


### PR DESCRIPTION
Added vuex-persist plugin.

2 Problems:

- Couldn't find a way to inject `$nuxt.$storage` to plugin, anyway may the storage be injected on runtime. How can access the nuxt context at the store files?

- in `vuex-persist.js` line 68:1, Used timeout to replaceState of store with persisted one.
It has some problems with SSR, As the server do not persist the state it won't be replaced during rendering, Also we have some problems on the client side, couldn't figure it out.
