### PR TITLE
feat: register $storage to root context

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,5 +6,6 @@ export default function nuxtUniversalStorage(ctx, inject) {
   const storage = new Storage(ctx, <%= JSON.stringify(options, null, 2) %>)
 
   // Inject into context as $storage
+  ctx.$storage = storage
   inject('storage', storage)
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,11 +32,17 @@ declare module '@nuxt/vue-app' {
   interface Context {
     $storage: NuxtStorage
   }
+  interface NuxtAppOptions {
+    $storage: NuxtStorage
+  }
 }
 
 // Nuxt 2.9+
 declare module '@nuxt/types' {
   interface Context {
+    $storage: NuxtStorage
+  }
+  interface NuxtAppOptions {
     $storage: NuxtStorage
   }
 }


### PR DESCRIPTION
Makes `$storage` accessible through `ctx.$storage` as shortcut of `ctx.app.$storage`, like `axios` (https://github.com/nuxt-community/axios-module/blob/master/lib/plugin.js#L200)

Also fix missing types for `ctx.app.$storage` (`NuxtAppOptions` type)